### PR TITLE
Update determine_gender_using_wes.py

### DIFF
--- a/determine_gender_using_wes.py
+++ b/determine_gender_using_wes.py
@@ -5,6 +5,8 @@ import pysam
 import os
 import concurrent.futures as cfutures
 import glob
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 
@@ -52,7 +54,7 @@ def get_gender(bam):
         bam=bam,
         yreads=sum([valid_read(read) for read in workfile.fetch(region='chrY:2649520-59034050')]),
         xreads=sum([valid_read(read) for read in workfile.fetch(region='chrX:2699520-154931044')]),
-        totalreads=workfile.mapped)
+        totalreads=float(workfile.mapped))
 
 
 def plot_genders(res):


### PR DESCRIPTION
- Adding a config value so matplotlib will use Agg which enables the script to draw the png even when called via ssh e.g. on an  HPC cluster
- Converting totalreads to float which helps avoid a division by zero error, e.g
if xreads = 34887
and if yreads = 654546
and totalreads = 34763509
Python will round the value xreads/totalreads to 0 and yreads/totalreads to 0, which results in division by zero in the first line of infer_gender()